### PR TITLE
Add cell coordinate labels back to game board

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1458,6 +1458,10 @@ const App: React.FC = () => {
         className={`cell ${isLastMove ? 'last-move' : ''}`}
         onClick={() => handleCellClick(row, col)}
       >
+        {/* Cell coordinate labels */}
+        <div className="cell-row-label">{8 - row}</div>
+        <div className="cell-col-label">{String.fromCharCode(97 + col)}</div>
+        
         {cell && (
           <>
             {/* Always render the ion (colored piece) */}


### PR DESCRIPTION
- Added row labels (8-1) in top-left corner of each cell
- Added column labels (a-h) in bottom-right corner of each cell
- Fixed missing chess notation display on board cells
- Labels use existing CSS classes .cell-row-label and .cell-col-label