### PR TITLE
Fix coordinate labels to show only on board edges

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1458,9 +1458,9 @@ const App: React.FC = () => {
         className={`cell ${isLastMove ? 'last-move' : ''}`}
         onClick={() => handleCellClick(row, col)}
       >
-        {/* Cell coordinate labels */}
-        <div className="cell-row-label">{8 - row}</div>
-        <div className="cell-col-label">{String.fromCharCode(97 + col)}</div>
+        {/* Cell coordinate labels - only show on edges like a chess board */}
+        {col === 0 && <div className="cell-row-label">{8 - row}</div>}
+        {row === 7 && <div className="cell-col-label">{String.fromCharCode(97 + col)}</div>}
         
         {cell && (
           <>


### PR DESCRIPTION
- Row numbers (8-1) now only appear in leftmost column (A column)
- Column letters (a-h) now only appear in bottom row (row 1)
- Removed coordinate labels from interior cells for cleaner look
- Matches traditional chess board labeling style